### PR TITLE
Add target="_blank" to YouTube and GitHub links for external navigation

### DIFF
--- a/AboutUs/index.html
+++ b/AboutUs/index.html
@@ -90,10 +90,10 @@
         <a class="item circle" href="#">
             <img class="img" alt="انستاغرام" width="30px" height="30px" src="../Source/Assets/Instagram.svg" />
         </a>
-        <a class="item circle" href="https://youtube.com/@aliflang47">
+        <a class="item circle" href="https://youtube.com/@aliflang47" target="_blank">
             <img class="img" alt="يوتيوب" width="30px" height="30px" src="../Source/Assets/Youtube.svg" />
         </a>
-        <a class="item circle" href="https://github.com/alifcommunity/Alif">
+        <a class="item circle" href="https://github.com/alifcommunity/Alif" target="_blank">
             <img class="img" alt="غيتهب" width="30px" height="30px" src="../Source/Assets/Github.svg" />
         </a>
     </section>

--- a/Contribution/index.html
+++ b/Contribution/index.html
@@ -126,10 +126,10 @@
         <a class="item circle" href="#">
             <img class="img" alt="انستاغرام" width="30px" height="30px" src="../Source/Assets/Instagram.svg" />
         </a>
-        <a class="item circle" href="https://youtube.com/@aliflang47">
+        <a class="item circle" href="https://youtube.com/@aliflang47" target="_blank">
             <img class="img" alt="يوتيوب" width="30px" height="30px" src="../Source/Assets/Youtube.svg" />
         </a>
-        <a class="item circle" href="https://github.com/alifcommunity/Alif">
+        <a class="item circle" href="https://github.com/alifcommunity/Alif" target="_blank">
             <img class="img" alt="غيتهب" width="30px" height="30px" src="../Source/Assets/Github.svg" />
         </a>
     </section>

--- a/Docs/index.html
+++ b/Docs/index.html
@@ -1058,10 +1058,10 @@
         <a class="item circle" href="#">
             <img class="img" alt="انستاغرام" width="30px" height="30px" src="../Source/Assets/Instagram.svg" />
         </a>
-        <a class="item circle" href="https://youtube.com/@aliflang47">
+        <a class="item circle" href="https://youtube.com/@aliflang47" target="_blank">
             <img class="img" alt="يوتيوب" width="30px" height="30px" src="../Source/Assets/Youtube.svg" />
         </a>
-        <a class="item circle" href="https://github.com/alifcommunity/Alif">
+        <a class="item circle" href="https://github.com/alifcommunity/Alif" target="_blank">
             <img class="img" alt="غيتهب" width="30px" height="30px" src="../Source/Assets/Github.svg" />
         </a>
     </section>

--- a/Download/index.html
+++ b/Download/index.html
@@ -76,10 +76,10 @@
 		<a class="item circle" href="#">
 			<img class="img" alt="انستاغرام" width="30px" height="30px" src="../Source/Assets/Instagram.svg" />
 		</a>
-		<a class="item circle" href="https://youtube.com/@aliflang47">
+		<a class="item circle" href="https://youtube.com/@aliflang47" target="_blank">
 			<img class="img" alt="يوتيوب" width="30px" height="30px" src="../Source/Assets/Youtube.svg" />
 		</a>
-		<a class="item circle" href="https://github.com/alifcommunity/Alif">
+		<a class="item circle" href="https://github.com/alifcommunity/Alif" target="_blank">
 			<img class="img" alt="غيتهب" width="30px" height="30px" src="../Source/Assets/Github.svg" />
 		</a>
 	</section>

--- a/Learn/index.html
+++ b/Learn/index.html
@@ -98,10 +98,10 @@
         <a class="item circle" href="#">
             <img class="img" alt="انستاغرام" width="30px" height="30px" src="../Source/Assets/Instagram.svg" />
         </a>
-        <a class="item circle" href="https://youtube.com/@aliflang47">
+        <a class="item circle" href="https://youtube.com/@aliflang47" target="_blank">
             <img class="img" alt="يوتيوب" width="30px" height="30px" src="../Source/Assets/Youtube.svg" />
         </a>
-        <a class="item circle" href="https://github.com/alifcommunity/Alif">
+        <a class="item circle" href="https://github.com/alifcommunity/Alif" target="_blank">
             <img class="img" alt="غيتهب" width="30px" height="30px" src="../Source/Assets/Github.svg" />
         </a>
     </section>

--- a/Libraries/index.html
+++ b/Libraries/index.html
@@ -81,10 +81,10 @@
         <a class="item circle" href="#">
             <img class="img" alt="انستاغرام" width="30px" height="30px" src="../Source/Assets/Instagram.svg" />
         </a>
-        <a class="item circle" href="https://youtube.com/@aliflang47">
+        <a class="item circle" href="https://youtube.com/@aliflang47" target="_blank">
             <img class="img" alt="يوتيوب" width="30px" height="30px" src="../Source/Assets/Youtube.svg" />
         </a>
-        <a class="item circle" href="https://github.com/alifcommunity/Alif">
+        <a class="item circle" href="https://github.com/alifcommunity/Alif" target="_blank">
             <img class="img" alt="غيتهب" width="30px" height="30px" src="../Source/Assets/Github.svg" />
         </a>
     </section>

--- a/License/index.html
+++ b/License/index.html
@@ -197,10 +197,10 @@
         <a class="item circle" href="#">
             <img class="img" alt="انستاغرام" width="30px" height="30px" src="../Source/Assets/Instagram.svg" />
         </a>
-        <a class="item circle" href="https://youtube.com/@aliflang47">
+        <a class="item circle" href="https://youtube.com/@aliflang47" target="_blank">
             <img class="img" alt="يوتيوب" width="30px" height="30px" src="../Source/Assets/Youtube.svg" />
         </a>
-        <a class="item circle" href="https://github.com/alifcommunity/Alif">
+        <a class="item circle" href="https://github.com/alifcommunity/Alif" target="_blank">
             <img class="img" alt="غيتهب" width="30px" height="30px" src="../Source/Assets/Github.svg" />
         </a>
     </section>

--- a/Support/index.html
+++ b/Support/index.html
@@ -87,10 +87,10 @@
         <a class="item circle" href="#">
             <img class="img" alt="انستاغرام" width="30px" height="30px" src="../Source/Assets/Instagram.svg" />
         </a>
-        <a class="item circle" href="https://youtube.com/@aliflang47">
+        <a class="item circle" href="https://youtube.com/@aliflang47" target="_blank">
             <img class="img" alt="يوتيوب" width="30px" height="30px" src="../Source/Assets/Youtube.svg" />
         </a>
-        <a class="item circle" href="https://github.com/alifcommunity/Alif">
+        <a class="item circle" href="https://github.com/alifcommunity/Alif" target="_blank">
             <img class="img" alt="غيتهب" width="30px" height="30px" src="../Source/Assets/Github.svg" />
         </a>
     </section>

--- a/index.html
+++ b/index.html
@@ -113,10 +113,10 @@
         <a class="item circle" href="#">
             <img class="img" alt="انستاغرام" width="30px" height="30px" src="Source/Assets/Instagram.svg" />
         </a>
-        <a class="item circle" href="https://youtube.com/@aliflang47">
+        <a class="item circle" href="https://youtube.com/@aliflang47" target="_blank">
             <img class="img" alt="يوتيوب" width="30px" height="30px" src="Source/Assets/Youtube.svg" />
         </a>
-        <a class="item circle" href="https://github.com/alifcommunity/Alif">
+        <a class="item circle" href="https://github.com/alifcommunity/Alif" target="_blank">
             <img class="img" alt="غيتهب" width="30px" height="30px" src="Source/Assets/Github.svg" />
         </a>
     </section>


### PR DESCRIPTION
This pull request updates multiple HTML files to enhance the user experience by ensuring external links open in a new tab. Specifically, the `target="_blank"` attribute has been added to links for YouTube and GitHub across various pages.